### PR TITLE
Add HTMLHint test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Welfare Site
+
+This repository contains a static website. Development dependencies are managed with npm.
+
+## Running Tests
+
+Use `npm test` to lint all HTML files with [HTMLHint](https://htmlhint.com/):
+
+```bash
+npm test
+```
+
+This command checks every `*.html` file in the project.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "welfare-gh-pages",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "htmlhint \"**/*.html\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "htmlhint": "^1.1.4"
+  }
+}


### PR DESCRIPTION
## Summary
- add npm config with htmlhint
- add `.gitignore` for node_modules
- document running tests in README

## Testing
- `npm test` *(fails: htmlhint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851668031a48329930fb7a614ad4653